### PR TITLE
Agregar tests de idempotencia y cache incremental

### DIFF
--- a/tests/idempotency.bats
+++ b/tests/idempotency.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+setup() {
+  make clean >/dev/null 2>&1
+}
+
+@test "Build es idempotente y determinista" {
+  run make build
+  [ "$status" -eq 0 ]
+  hash1=$(find out/ -type f -exec sha256sum {} \; | sort | sha256sum)
+
+  run make build
+  [ "$status" -eq 0 ]
+  hash2=$(find out/ -type f -exec sha256sum {} \; | sort | sha256sum)
+
+  run make build
+  [ "$status" -eq 0 ]
+  hash3=$(find out/ -type f -exec sha256sum {} \; | sort | sha256sum)
+
+  [ "$hash1" = "$hash2" ]
+  [ "$hash2" = "$hash3" ]
+}

--- a/tests/incremental_cache.bats
+++ b/tests/incremental_cache.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+setup() {
+  make clean >/dev/null 2>&1
+  cp src/hello_service.sh /tmp/hello_service_backup.sh
+  cp /tmp/hello_service_backup.sh src/hello_service.sh
+}
+
+teardown() {
+  mv /tmp/hello_service_backup.sh src/hello_service.sh
+}
+
+@test "Cache incremental detecta cambios y reconstruye" {
+  run make build
+  [ "$status" -eq 0 ]
+  timestamp1=$(stat -c %Y out/build.timestamp 2>/dev/null || echo "0")
+
+  sleep 1
+
+  sed -i '1i# Cambio de test '"$(date +%s)" src/hello_service.sh
+
+  run make build
+  [ "$status" -eq 0 ]
+  timestamp2=$(stat -c %Y out/build.timestamp 2>/dev/null || echo "0")
+
+  [ "$timestamp2" -gt "$timestamp1" ]
+}
+
+@test "Cache incremental usa cache cuando no hay cambios" {
+  run make build
+  [ "$status" -eq 0 ]
+  timestamp1=$(stat -c %Y out/build.timestamp 2>/dev/null || echo "0")
+
+  sleep 1
+
+  run make build
+  [ "$status" -eq 0 ]
+  timestamp2=$(stat -c %Y out/build.timestamp 2>/dev/null || echo "0")
+
+  [ "$timestamp2" -eq "$timestamp1" ]
+}


### PR DESCRIPTION
Se agregan dos tests BATS para mejorar la robustez del proceso de build:

- [ ] idempotency.bats: verifica que multiples ejecuciones del build produzcan artefactos identicos, asegurando idempotencia y determinismo.
- [ ] incremental_cache.bats: valida que el sistema detecte cambios en el codigo fuente y reconstruya correctamente, usando cache incremental cuando no hay cambios.